### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Fly.io
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dauble/fantasy-f1/security/code-scanning/1](https://github.com/dauble/fantasy-f1/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so all jobs inherit least-privilege token access.  
For this file, the best minimal fix is to set:

- `permissions:`
  - `contents: read`

at the workflow root (top-level, near `name`/`on`), since there is only one job and no write scope appears required.

**File to change:** `.github/workflows/deploy.yml`  
**Region:** after `name` and before `on` (top-level YAML keys).  
No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
