### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -158,7 +158,7 @@ app.use(express.static(DIST));
 
 // Fallback: send index.html for all non-API routes (React Router)
 // Note: Express 5 doesn't support app.get("*") — use middleware instead
-app.use((req, res) => {
+app.use(rateLimiter, (req, res) => {
   if (req.path.startsWith("/api/")) {
     return res.status(404).json({ error: "Not found" });
   }

--- a/server.js
+++ b/server.js
@@ -154,11 +154,13 @@ app.delete("/api/news/cache", (_req, res) => {
 // ─── Serve Vite build ─────────────────────────────────────────────────────────
 
 const DIST = join(__dirname, "dist");
+// Apply rate limiting to all static file and SPA routes
+app.use(rateLimiter);
 app.use(express.static(DIST));
 
 // Fallback: send index.html for all non-API routes (React Router)
 // Note: Express 5 doesn't support app.get("*") — use middleware instead
-app.use(rateLimiter, (req, res) => {
+app.use((req, res) => {
   if (req.path.startsWith("/api/")) {
     return res.status(404).json({ error: "Not found" });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/dauble/fantasy-f1/security/code-scanning/2](https://github.com/dauble/fantasy-f1/security/code-scanning/2)

Add the existing `rateLimiter` middleware to the SPA fallback middleware so requests that trigger `sendFile(index.html)` are rate-limited as well.

Best fix in this file:
- In `server.js`, update the fallback route registration from:
  - `app.use((req, res) => { ... })`
  to:
  - `app.use(rateLimiter, (req, res) => { ... })`
- This reuses the already-defined limiter (no new imports/dependencies) and preserves existing behavior for routing, while adding request throttling to the filesystem access path CodeQL identified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
